### PR TITLE
Refactor inithw

### DIFF
--- a/DLL/AudioCapture/Hardware.cpp
+++ b/DLL/AudioCapture/Hardware.cpp
@@ -24,7 +24,6 @@
 #include <winlirc/winlirc_api.h>
 #include <winlirc/WLPluginAPI.h>
 
-hardware hw;
 rbuf rec_buffer;
 
 lirc_t readdata(lirc_t timeout) {
@@ -56,20 +55,18 @@ void wait_for_data(lirc_t uSecs) {
 	waitTillDataIsReady(std::chrono::microseconds{ uSecs });
 }
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readdata;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"audio");
-}
+extern hardware const audio_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "audio",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution    = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readdata,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/AudioCapture/WinlircAudioIn.cpp
+++ b/DLL/AudioCapture/WinlircAudioIn.cpp
@@ -32,8 +32,7 @@
 #include <cstdio>
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const audio_hw;
 extern rbuf rec_buffer;
 
 //For the GUI
@@ -59,7 +58,6 @@ WL_API int init(winlirc_api const* winlirc) {
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
 	threadExitEvent	= reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 
-	initHardwareStruct();
 	winlirc_init_rec_buffer(&rec_buffer);
 
 	settings->loadSettings();
@@ -424,9 +422,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 		return 0;
 	}
 
-	winlirc_clear_rec_buffer(&rec_buffer, &hw);
+	winlirc_clear_rec_buffer(&rec_buffer, &audio_hw);
 
-	if(winlirc_decodeCommand(&rec_buffer, &hw, remotes, out, out_size)) {
+	if(winlirc_decodeCommand(&rec_buffer, &audio_hw, remotes, out, out_size)) {
 		return 1;
 	}
 	
@@ -435,7 +433,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 
 WL_API struct hardware const* getHardware() {
 
-	initHardwareStruct();	//make sure values are setup
-
-	return &hw;
+	return &audio_hw;
 }

--- a/DLL/Beholder/Beholder.cpp
+++ b/DLL/Beholder/Beholder.cpp
@@ -25,14 +25,11 @@
 #include <winlirc/WLPluginAPI.h>
 #include <winlirc/winlirc_api.h>
 
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const beholder_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc)
 {
-	initHardwareStruct();
-
 	InitializeCriticalSection(&criticalSection);
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
@@ -89,7 +86,7 @@ WL_API int decodeIR( struct ir_remote *remotes, char *out, size_t out_size )
 			return 0;
 		}
 	   	
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &beholder_hw,remotes,out,out_size)) {
 			ResetEvent(dataReadyEvent);
 			return 1;
 		}
@@ -102,6 +99,5 @@ WL_API int decodeIR( struct ir_remote *remotes, char *out, size_t out_size )
 
 WL_API hardware const* getHardware() {
 
-	initHardwareStruct();
-	return &hw;
+	return &beholder_hw;
 }

--- a/DLL/Beholder/Hardware.cpp
+++ b/DLL/Beholder/Hardware.cpp
@@ -67,23 +67,20 @@ int data_ready() {
 	return sendReceiveData->dataReady();
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &beholder_decode;
-	hw.readdata		= nullptr;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 32;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"Beholder");
-}
+extern hardware const beholder_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "Beholder",
+	.features      = LIRC_CAN_REC_LIRCCODE,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_LIRCCODE,
+	.code_length   = 32,
+	.resolution    = 0,
+	.decode_func   = &beholder_decode,
+	.readdata      = nullptr,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = &get_ir_code,
+};

--- a/DLL/CommandIR/CommandIR.cpp
+++ b/DLL/CommandIR/CommandIR.cpp
@@ -32,8 +32,7 @@
 #include "winlirc.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const commandir_hw;
 extern rbuf rec_buffer;
 extern sbuf send_buffer;
 
@@ -45,7 +44,6 @@ WL_API int init(winlirc_api const* winlirc) {
 
 	winlirc_init_rec_buffer		(&rec_buffer);
 	winlirc_init_send_buffer	(&send_buffer);
-	initHardwareStruct	();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
@@ -84,9 +82,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 		return 0;
 	}
 
-	winlirc_clear_rec_buffer(&rec_buffer, &hw);
+	winlirc_clear_rec_buffer(&rec_buffer, &commandir_hw);
 	
-	if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+	if(winlirc_decodeCommand(&rec_buffer, &commandir_hw,remotes,out,out_size)) {
 		return 1;
 	}
 
@@ -102,7 +100,6 @@ WL_API int setTransmitters(unsigned int transmitterMask) {
 
 WL_API hardware const* getHardware() {
 
-	initHardwareStruct();
-	return &hw;
+	return &commandir_hw;
 
 }

--- a/DLL/CommandIR/Hardware.cpp
+++ b/DLL/CommandIR/Hardware.cpp
@@ -28,7 +28,6 @@
 // and not needed for winlirc itself
 //
 
-hardware hw;
 rbuf rec_buffer;
 
 lirc_t readData(lirc_t timeout) {
@@ -57,20 +56,18 @@ int data_ready() {
 	return 0;
 }
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"CommandIR");
-}
+extern hardware const commandir_hw = {
+    .plugin_api_version = winlirc_plugin_api_version,
+    .device        = "hw",
+    .name          = "CommandIR",
+    .features      = LIRC_CAN_REC_MODE2,
+    .send_mode     = 0,
+    .rec_mode      = LIRC_MODE_MODE2,
+    .code_length   = 0,
+    .resolution    = 0,
+    .decode_func   = &winlirc_receive_decode,
+    .readdata      = &readData,
+    .wait_for_data = &wait_for_data,
+    .data_ready    = &data_ready,
+    .get_ir_code   = nullptr,
+};

--- a/DLL/Cyberlink/CyberLink.cpp
+++ b/DLL/Cyberlink/CyberLink.cpp
@@ -27,8 +27,7 @@
 #include "Globals.h"
 #include "ReceiveData.h"
 
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const cyberlink_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc)
@@ -85,7 +84,7 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size)
 
 		receiveData->getData((lirc_t*)&irCode);
 
-		if (winlirc_decodeCommand(&rec_buffer, &hw,remotes, out, out_size) ) {
+		if (winlirc_decodeCommand(&rec_buffer, &cyberlink_hw,remotes, out, out_size) ) {
 			return 1;
 		}
 	}
@@ -96,5 +95,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size)
 WL_API hardware const* getHardware()
 {
 	initHardwareStruct();
-	return &hw;
+	return &cyberlink_hw;
 }

--- a/DLL/Cyberlink/CyberLink.cpp
+++ b/DLL/Cyberlink/CyberLink.cpp
@@ -32,8 +32,6 @@ extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc)
 {
-	initHardwareStruct();
-
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
 
@@ -94,6 +92,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size)
 
 WL_API hardware const* getHardware()
 {
-	initHardwareStruct();
 	return &cyberlink_hw;
 }

--- a/DLL/Cyberlink/Hardware.cpp
+++ b/DLL/Cyberlink/Hardware.cpp
@@ -26,7 +26,6 @@
 
 #define CODE_LENGTH 32
 
-hardware hw;
 rbuf rec_buffer;
 
 static int cyberlink_receive_decode (rbuf* rec_buffer, hardware const*, ir_remote *remote, ir_code *prep, ir_code *codep,
@@ -71,20 +70,18 @@ int data_ready() {
 	return 0;
 }
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &cyberlink_receive_decode;
-	hw.readdata		= nullptr;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 32;
-	hw.resolution	= 0;
-
-	strcpy_s(hw.device,"hw");
-	strcpy_s(hw.name,"CyberLink");
-}
+extern hardware const cyberlink_hw = {
+    .plugin_api_version = winlirc_plugin_api_version,
+    .device        = "hw",
+    .name          = "CyberLink",
+    .features      = LIRC_CAN_REC_LIRCCODE,
+    .send_mode     = 0,
+    .rec_mode      = LIRC_MODE_LIRCCODE,
+    .code_length   = 32,
+    .resolution    = 0,
+    .decode_func   = &cyberlink_receive_decode,
+    .readdata      = nullptr,
+    .wait_for_data = &wait_for_data,
+    .data_ready    = &data_ready,
+    .get_ir_code   = &get_ir_code,
+};

--- a/DLL/Geniatech/GeniatechRC.cpp
+++ b/DLL/Geniatech/GeniatechRC.cpp
@@ -16,13 +16,11 @@
 using namespace std::chrono;
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const geniatech_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
 
-	initHardwareStruct();
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(NULL,FALSE,FALSE,NULL);
 
@@ -127,7 +125,7 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 		receive->getData(&irCode);
 		end = steady_clock::now();
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &geniatech_hw,remotes,out,out_size)) {
 			ResetEvent(dataReadyEvent);
 			return 1;
 		}
@@ -140,6 +138,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 
 WL_API hardware const* getHardware() {
 
-	initHardwareStruct();
-	return &hw;
+	return &geniatech_hw;
 }

--- a/DLL/Geniatech/Hardware.cpp
+++ b/DLL/Geniatech/Hardware.cpp
@@ -71,23 +71,20 @@ int data_ready() {
 	return receive->dataReady();
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &gnt_decode;
-	hw.readdata		= NULL;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 32;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"Geniatech");
-}
+extern hardware const geniatech_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "Geniatech",
+	.features      = LIRC_CAN_REC_LIRCCODE,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_LIRCCODE,
+	.code_length   = 32,
+	.resolution    = 0,
+	.decode_func   = &gnt_decode,
+	.readdata      = nullptr,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = &get_ir_code,
+};

--- a/DLL/IRMan/Hardware.cpp
+++ b/DLL/IRMan/Hardware.cpp
@@ -79,23 +79,20 @@ int data_ready() {
 	return sendReceiveData->dataReady();
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &irman_decode;
-	hw.readdata		= nullptr;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &irman_get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 64;
-	hw.resolution	= 0;
-
-	strcpy_s(hw.device,"hw");
-	strcpy_s(hw.name,"irman");
-}
+extern hardware const irman_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "irman",
+	.features      = LIRC_CAN_REC_LIRCCODE,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_LIRCCODE,
+	.code_length   = 64,
+	.resolution    = 0,
+	.decode_func   = &irman_decode,
+	.readdata      = nullptr,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = &irman_get_ir_code,
+};

--- a/DLL/IRMan/IRMan.cpp
+++ b/DLL/IRMan/IRMan.cpp
@@ -29,13 +29,10 @@
 #include "resource.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const irman_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
-
-	initHardwareStruct();
 
 	InitializeCriticalSection(&criticalSection);
 
@@ -174,7 +171,7 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 			return 0;
 		}
 		
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &irman_hw,remotes,out,out_size)) {
 			ResetEvent(dataReadyEvent);
 			return 1;
 		}
@@ -188,6 +185,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 
 WL_API hardware const* getHardware() {
 
-	initHardwareStruct();
-	return &hw;
+	return &irman_hw;
 }

--- a/DLL/IRToy/Hardware.cpp
+++ b/DLL/IRToy/Hardware.cpp
@@ -56,23 +56,20 @@ int data_ready() {
 	return 0;
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"IRToy");
-}
+extern hardware const irtoy_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "IRToy",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution    = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readData,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/IRToy/IRToy.cpp
+++ b/DLL/IRToy/IRToy.cpp
@@ -30,14 +30,12 @@
 #include <tchar.h>
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const irtoy_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
 
 	winlirc_init_rec_buffer(&rec_buffer);
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
@@ -176,9 +174,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 			return 0;
 		}
 
-		winlirc_clear_rec_buffer(&rec_buffer, &hw);
+		winlirc_clear_rec_buffer(&rec_buffer, &irtoy_hw);
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &irtoy_hw,remotes,out,out_size)) {
 			return 1;
 		}
 	}
@@ -188,6 +186,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 
 WL_API hardware const* getHardware() {
 
-	initHardwareStruct();
-	return &hw;
+	return &irtoy_hw;
 }

--- a/DLL/Iguana/Hardware.cpp
+++ b/DLL/Iguana/Hardware.cpp
@@ -23,7 +23,6 @@
 #include <winlirc/winlirc_api.h>
 #include <winlirc/WLPluginAPI.h>
 
-hardware iguana_hw;
 rbuf rec_buffer;
 
 lirc_t readData(lirc_t timeout) {
@@ -59,20 +58,18 @@ int data_ready() {
 	return 0;
 }
 
-void initHardwareStruct() {
-
-	iguana_hw.decode_func	= &winlirc_receive_decode;
-	iguana_hw.readdata		= &readData;
-	iguana_hw.wait_for_data= &wait_for_data;
-	iguana_hw.data_ready	= &data_ready;
-	iguana_hw.get_ir_code	= nullptr;
-
-	iguana_hw.features		= LIRC_CAN_REC_MODE2;
-	iguana_hw.send_mode	= 0;
-	iguana_hw.rec_mode		= LIRC_MODE_MODE2;
-	iguana_hw.code_length	= 0;
-	iguana_hw.resolution	= 0;
-
-	strcpy(iguana_hw.device,"hw");
-	strcpy(iguana_hw.name,"iguanaIR");
-}
+extern hardware const iguana_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "iguanaIR",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution    = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readData,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/Iguana/Hardware.cpp
+++ b/DLL/Iguana/Hardware.cpp
@@ -23,7 +23,7 @@
 #include <winlirc/winlirc_api.h>
 #include <winlirc/WLPluginAPI.h>
 
-hardware hw;
+hardware iguana_hw;
 rbuf rec_buffer;
 
 lirc_t readData(lirc_t timeout) {
@@ -61,18 +61,18 @@ int data_ready() {
 
 void initHardwareStruct() {
 
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
+	iguana_hw.decode_func	= &winlirc_receive_decode;
+	iguana_hw.readdata		= &readData;
+	iguana_hw.wait_for_data= &wait_for_data;
+	iguana_hw.data_ready	= &data_ready;
+	iguana_hw.get_ir_code	= nullptr;
 
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
+	iguana_hw.features		= LIRC_CAN_REC_MODE2;
+	iguana_hw.send_mode	= 0;
+	iguana_hw.rec_mode		= LIRC_MODE_MODE2;
+	iguana_hw.code_length	= 0;
+	iguana_hw.resolution	= 0;
 
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"iguanaIR");
+	strcpy(iguana_hw.device,"hw");
+	strcpy(iguana_hw.name,"iguanaIR");
 }

--- a/DLL/Iguana/Iguana.cpp
+++ b/DLL/Iguana/Iguana.cpp
@@ -30,8 +30,7 @@
 #include "SendReceiveData.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware iguana_hw;
+extern hardware const iguana_hw;
 extern rbuf rec_buffer;
 extern sbuf send_buffer;
 
@@ -39,7 +38,6 @@ WL_API int init(winlirc_api const* winlirc) {
 
 	winlirc_init_rec_buffer(&rec_buffer);
 	winlirc_init_send_buffer(&send_buffer);
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
@@ -215,7 +213,5 @@ WL_API int setTransmitters(unsigned int transmitterMask) {
 
 WL_API hardware const* getHardware() {
 
-	initHardwareStruct();
 	return &iguana_hw;
-
 }

--- a/DLL/Iguana/Iguana.cpp
+++ b/DLL/Iguana/Iguana.cpp
@@ -31,7 +31,7 @@
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 void initHardwareStruct();
-extern hardware hw;
+extern hardware iguana_hw;
 extern rbuf rec_buffer;
 extern sbuf send_buffer;
 
@@ -194,9 +194,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 			return 0;
 		}
 
-		winlirc_clear_rec_buffer(&rec_buffer, &hw);
+		winlirc_clear_rec_buffer(&rec_buffer, &iguana_hw);
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &iguana_hw,remotes,out,out_size)) {
 			return 1;
 		}
 	}
@@ -216,6 +216,6 @@ WL_API int setTransmitters(unsigned int transmitterMask) {
 WL_API hardware const* getHardware() {
 
 	initHardwareStruct();
-	return &hw;
+	return &iguana_hw;
 
 }

--- a/DLL/Irdroid/Hardware.cpp
+++ b/DLL/Irdroid/Hardware.cpp
@@ -56,23 +56,20 @@ int data_ready() {
 	return 0;
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"Irdroid");
-}
+extern hardware const irdroid_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "Irdroid",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution    = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readData,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/Irdroid/Irdroid.cpp
+++ b/DLL/Irdroid/Irdroid.cpp
@@ -30,14 +30,12 @@
 #include <tchar.h>
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const irdroid_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
 
 	winlirc_init_rec_buffer(&rec_buffer);
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
@@ -177,9 +175,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 			return 0;
 		}
 
-		winlirc_clear_rec_buffer(&rec_buffer, &hw);
+		winlirc_clear_rec_buffer(&rec_buffer, &irdroid_hw);
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &irdroid_hw,remotes,out,out_size)) {
 			return 1;
 		}
 	}
@@ -189,6 +187,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 
 WL_API hardware const* getHardware() {
 
-	initHardwareStruct();
-	return &hw;
+	return &irdroid_hw;
 }

--- a/DLL/MCE-XP/Hardware.cpp
+++ b/DLL/MCE-XP/Hardware.cpp
@@ -23,7 +23,6 @@
 #include <winlirc/winlirc_api.h>
 #include <winlirc/WLPluginAPI.h>
 
-hardware hw;
 
 lirc_t readData(lirc_t timeout) {
 
@@ -58,20 +57,17 @@ int data_ready() {
 	return 0;
 }
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"MCE");
-}
+extern hardware const mcexp_hw = {
+	.device        = "hw",
+	.name          = "MCE",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution    = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readData,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/MCE-XP/MCE.cpp
+++ b/DLL/MCE-XP/MCE.cpp
@@ -29,8 +29,7 @@
 #include "Registry.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const mcexp_hw;
 rbuf rec_buffer;
 static sbuf send_buffer;
 
@@ -38,7 +37,6 @@ WL_API int init(winlirc_api const* winlirc) {
 
 	winlirc_init_rec_buffer(&rec_buffer);
 	winlirc_init_send_buffer(&send_buffer);
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
@@ -204,9 +202,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 			return 0;
 		}
 
-		winlirc_clear_rec_buffer(&rec_buffer, &hw);
+		winlirc_clear_rec_buffer(&rec_buffer, &mcexp_hw);
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &mcexp_hw,remotes,out,out_size)) {
 			return 1;
 		}
 	}
@@ -215,8 +213,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
-
+	return &mcexp_hw;
 }

--- a/DLL/MCE/Hardware.cpp
+++ b/DLL/MCE/Hardware.cpp
@@ -23,7 +23,6 @@
 #include <winlirc/winlirc_api.h>
 #include <winlirc/WLPluginAPI.h>
 
-hardware hw;
 rbuf rec_buffer;
 
 lirc_t readData(lirc_t timeout) {
@@ -59,20 +58,17 @@ int data_ready() {
 	return 0;
 }
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"MCE");
-}
+extern hardware const mce_hw = {
+	.device        = "hw",
+	.name          = "MCE",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution    = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readData,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/MCE/MCE.cpp
+++ b/DLL/MCE/MCE.cpp
@@ -30,8 +30,7 @@
 #include "Registry.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const mce_hw;
 extern rbuf rec_buffer;
 HANDLE hMutexLockout = nullptr;
 
@@ -44,7 +43,6 @@ WL_API int init(winlirc_api const* winlirc) {
 	}
 
 	winlirc_init_rec_buffer(&rec_buffer);
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
@@ -213,9 +211,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 			return 0;
 		}
 
-		winlirc_clear_rec_buffer(&rec_buffer, &hw);
+		winlirc_clear_rec_buffer(&rec_buffer, &mce_hw);
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &mce_hw,remotes,out,out_size)) {
 			return 1;
 		}
 	}
@@ -234,8 +232,5 @@ WL_API int setTransmitters(unsigned int transmitterMask) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
-
+	return &mce_hw;
 }

--- a/DLL/Streamzap/Hardware.cpp
+++ b/DLL/Streamzap/Hardware.cpp
@@ -23,7 +23,6 @@
 #include <winlirc/winlirc_api.h>
 #include <winlirc/WLPluginAPI.h>
 
-struct hardware hw;
 rbuf rec_buffer;
 
 lirc_t readData(lirc_t timeout) {
@@ -59,20 +58,17 @@ int data_ready() {
 	return 0;
 }
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"Streamzap");
-}
+extern hardware const streamzap_hw = {
+	.device        = "hw",
+	.name          = "Streamzap",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution    = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readData,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/Streamzap/Streamzap.cpp
+++ b/DLL/Streamzap/Streamzap.cpp
@@ -25,14 +25,12 @@
 #include <stdio.h>
 #include "Globals.h"
 
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const streamzap_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
 
 	winlirc_init_rec_buffer(&rec_buffer);
-	initHardwareStruct();
 
 	streamzapAPI = new StreamzapAPI();
 
@@ -70,9 +68,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 			return 0;
 		}
 
-		winlirc_clear_rec_buffer(&rec_buffer, &hw);
+		winlirc_clear_rec_buffer(&rec_buffer, &streamzap_hw);
 		
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out, out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &streamzap_hw,remotes,out, out_size)) {
 			return 1;
 		}
 	}
@@ -81,7 +79,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
+	return &streamzap_hw;
 }

--- a/DLL/TbsCxt/Hardware.cpp
+++ b/DLL/TbsCxt/Hardware.cpp
@@ -69,23 +69,19 @@ int data_ready() {
 	return receive->dataReady();
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &tbs_decode;
-	hw.readdata		= nullptr;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 32;
-	hw.resolution	= 0;
-
-	strcpy_s(hw.device,"hw");
-	strcpy_s(hw.name,"TbsCxt");
-}
+extern hardware const tbscxt_hw = {
+	.device        = "hw",
+	.name          = "TbsCxt",
+	.features      = LIRC_CAN_REC_LIRCCODE,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_LIRCCODE,
+	.code_length   = 32,
+	.resolution    = 0,
+	.decode_func   = &tbs_decode,
+	.readdata      = nullptr,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = &get_ir_code,
+};

--- a/DLL/TbsCxt/TbsCxtRC.cpp
+++ b/DLL/TbsCxt/TbsCxtRC.cpp
@@ -12,13 +12,10 @@
 #include "../Common/Win32Helpers.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const tbscxt_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
-	initHardwareStruct();
-
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,FALSE,FALSE,nullptr);
 
@@ -211,7 +208,7 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 		receive->getData(&irCode);
 		end = std::chrono::steady_clock::now();
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &tbscxt_hw,remotes,out,out_size)) {
 			ResetEvent(dataReadyEvent);
 			return 1;
 		}
@@ -224,7 +221,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
+	return &tbscxt_hw;
 }

--- a/DLL/TbsQBOX/Hardware.cpp
+++ b/DLL/TbsQBOX/Hardware.cpp
@@ -70,23 +70,19 @@ int data_ready() {
 	return receive->dataReady();
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &tbs_decode;
-	hw.readdata		= nullptr;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 32;
-	hw.resolution	= 0;
-
-	strcpy_s(hw.device,"hw");
-	strcpy_s(hw.name,"TbsCxt");
-}
+extern hardware const tbsqbox_hw = {
+	.device        = "hw",
+	.name          = "TbsCxt",
+	.features      = LIRC_CAN_REC_LIRCCODE,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_LIRCCODE,
+	.code_length   = 32,
+	.resolution    = 0,
+	.decode_func   = &tbs_decode,
+	.readdata      = nullptr,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = &get_ir_code,
+};

--- a/DLL/TbsQBOX/TbsQboxRC.cpp
+++ b/DLL/TbsQBOX/TbsQboxRC.cpp
@@ -12,13 +12,10 @@
 #include "../Common/Win32Helpers.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const tbsqbox_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
-	initHardwareStruct();
-
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,FALSE,FALSE,nullptr);
 
@@ -211,7 +208,7 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 		receive->getData(&irCode);
 		end = std::chrono::steady_clock::now();
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &tbsqbox_hw,remotes,out,out_size)) {
 			ResetEvent(dataReadyEvent);
 			return 1;
 		}
@@ -223,7 +220,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
+	return &tbsqbox_hw;
 }

--- a/DLL/TeVii/Hardware.cpp
+++ b/DLL/TeVii/Hardware.cpp
@@ -71,23 +71,20 @@ int data_ready() {
 	return receive->dataReady();
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &tevii_decode;
-	hw.readdata		= nullptr;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 32;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"TeVii-BDA");
-}
+extern hardware const tevii_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "TeVii-BDA",
+	.features      = LIRC_CAN_REC_LIRCCODE,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_LIRCCODE,
+	.code_length   = 32,
+	.resolution    = 0,
+	.decode_func   = &tevii_decode,
+	.readdata      = nullptr,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = &get_ir_code,
+};

--- a/DLL/TeVii/TeViiRC.cpp
+++ b/DLL/TeVii/TeViiRC.cpp
@@ -16,13 +16,10 @@
 using namespace std::chrono;
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const tevii_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
-
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,FALSE,FALSE,nullptr);
@@ -160,7 +157,7 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 		receive->getData(&irCode);
 		end = steady_clock::now();
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &tevii_hw,remotes,out,out_size)) {
 			ResetEvent(dataReadyEvent);
 			return 1;
 		}
@@ -172,7 +169,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
+	return &tevii_hw;
 }

--- a/DLL/Technisat/Hardware.cpp
+++ b/DLL/Technisat/Hardware.cpp
@@ -63,23 +63,19 @@ int data_ready() {
 	return receive->dataReady();
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &technisat_decode;
-	hw.readdata		= nullptr;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 32;
-	hw.resolution	= 0;
-
-	strcpy_s(hw.device,"hw");
-	strcpy_s(hw.name,"Technisat");
-}
+extern hardware const technisat_hw = {
+	.device        = "hw",
+	.name          = "Technisat",
+	.features      = LIRC_CAN_REC_LIRCCODE,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_LIRCCODE,
+	.code_length   = 32,
+	.resolution    = 0,
+	.decode_func   = &technisat_decode,
+	.readdata      = nullptr,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = &get_ir_code,
+};

--- a/DLL/Technisat/TechnisatRC.cpp
+++ b/DLL/Technisat/TechnisatRC.cpp
@@ -10,13 +10,10 @@
 #include "../Common/Win32helpers.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const technisat_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
-
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,FALSE,FALSE,nullptr);
@@ -159,7 +156,7 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 		receive->getData(&irCode);
 		end = std::chrono::steady_clock::now();
 
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &technisat_hw,remotes,out,out_size)) {
 			ResetEvent(dataReadyEvent);
 			return 1;
 		}
@@ -171,7 +168,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
+	return &technisat_hw;
 }

--- a/DLL/Technotrend/Hardware.cpp
+++ b/DLL/Technotrend/Hardware.cpp
@@ -56,23 +56,19 @@ int data_ready() {
 	return 0;
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"TechnoTrend USB Infrared Receiver");
-}
+extern hardware const technotrend_hw = {
+	.device        = "hw",
+	.name          = "TechnoTrend USB Infrared Receiver",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution    = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readData,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/Technotrend/Technotrend.cpp
+++ b/DLL/Technotrend/Technotrend.cpp
@@ -12,14 +12,12 @@
 #include "Settings.h"
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const technotrend_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
 
 	winlirc_init_rec_buffer(&rec_buffer);
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
@@ -171,9 +169,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 		}
 	}
 
-	winlirc_clear_rec_buffer(&rec_buffer, &hw);
+	winlirc_clear_rec_buffer(&rec_buffer, &technotrend_hw);
 
-	if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+	if(winlirc_decodeCommand(&rec_buffer, &technotrend_hw,remotes,out,out_size)) {
 		return 1;
 	}
 
@@ -181,7 +179,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
+	return &technotrend_hw;
 }

--- a/DLL/Tira/Hardware.cpp
+++ b/DLL/Tira/Hardware.cpp
@@ -129,23 +129,19 @@ void wait_for_data(lirc_t timeout) {
 	waitForData(std::chrono::microseconds{ timeout });
 }
 
-hardware hw;
 rbuf rec_buffer;
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &tira_decode;
-	hw.readdata		= nullptr;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= &get_ir_code;
-
-	hw.features		= LIRC_CAN_REC_LIRCCODE;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_LIRCCODE;
-	hw.code_length	= 64;
-	hw.resolution	= 0;
-
-	strcpy_s(hw.device,"hw");
-	strcpy_s(hw.name,"irman");
-}
+extern hardware const tira_hw = {
+	.device        = "hw",
+	.name          = "irman",
+	.features      = LIRC_CAN_REC_LIRCCODE,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_LIRCCODE,
+	.code_length   = 64,
+	.resolution    = 0,
+	.decode_func   = &tira_decode,
+	.readdata      = nullptr,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = &get_ir_code,
+};

--- a/DLL/Tira/Tira.cpp
+++ b/DLL/Tira/Tira.cpp
@@ -10,8 +10,7 @@
 #include <winlirc/winlirc_api.h>
 
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const tira_hw;
 extern rbuf rec_buffer;
 
 //===================
@@ -192,7 +191,7 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 
 	end = std::chrono::steady_clock::now();
 
-	if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+	if(winlirc_decodeCommand(&rec_buffer, &tira_hw,remotes,out,out_size)) {
 		ResetEvent(dataReadyEvent);
 		return 1;
 	}
@@ -203,7 +202,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 }
 
 WL_API hardware const* getHardware() {
-
-	initHardwareStruct();
-	return &hw;
+	return &tira_hw;
 }

--- a/DLL/UDP/Hardware.cpp
+++ b/DLL/UDP/Hardware.cpp
@@ -24,7 +24,6 @@
 #include <winlirc/winlirc_api.h>
 #include <winlirc/WLPluginAPI.h>
 
-struct hardware hw;
 rbuf rec_buffer;
 
 lirc_t readData(lirc_t timeout) {
@@ -60,20 +59,18 @@ int data_ready() {
 	return 0;
 }
 
-void initHardwareStruct() {
-
-	hw.decode_func	= &winlirc_receive_decode;
-	hw.readdata		= &readData;
-	hw.wait_for_data= &wait_for_data;
-	hw.data_ready	= &data_ready;
-	hw.get_ir_code	= nullptr;
-
-	hw.features		= LIRC_CAN_REC_MODE2;
-	hw.send_mode	= 0;
-	hw.rec_mode		= LIRC_MODE_MODE2;
-	hw.code_length	= 0;
-	hw.resolution	= 0;
-
-	strcpy(hw.device,"hw");
-	strcpy(hw.name,"udp");
-}
+extern hardware const udp_hw = {
+	.plugin_api_version = winlirc_plugin_api_version,
+	.device        = "hw",
+	.name          = "udp",
+	.features      = LIRC_CAN_REC_MODE2,
+	.send_mode     = 0,
+	.rec_mode      = LIRC_MODE_MODE2,
+	.code_length   = 0,
+	.resolution	   = 0,
+	.decode_func   = &winlirc_receive_decode,
+	.readdata      = &readData,
+	.wait_for_data = &wait_for_data,
+	.data_ready    = &data_ready,
+	.get_ir_code   = nullptr,
+};

--- a/DLL/UDP/UDP.cpp
+++ b/DLL/UDP/UDP.cpp
@@ -27,8 +27,7 @@
 #include <stdio.h>
 #include "Globals.h"
 
-void initHardwareStruct();
-extern hardware hw;
+extern hardware const udp_hw;
 extern rbuf rec_buffer;
 
 WL_API int init(winlirc_api const* winlirc) {
@@ -38,7 +37,6 @@ WL_API int init(winlirc_api const* winlirc) {
 	//===========
 
 	winlirc_init_rec_buffer(&rec_buffer);
-	initHardwareStruct();
 
 	threadExitEvent = reinterpret_cast<HANDLE>(winlirc->getExitEvent(winlirc));
 	dataReadyEvent	= CreateEvent(nullptr,TRUE,FALSE,nullptr);
@@ -84,9 +82,9 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 			return 0;
 		}
 
-		winlirc_clear_rec_buffer(&rec_buffer, &hw);
+		winlirc_clear_rec_buffer(&rec_buffer, &udp_hw);
 		
-		if(winlirc_decodeCommand(&rec_buffer, &hw,remotes,out,out_size)) {
+		if(winlirc_decodeCommand(&rec_buffer, &udp_hw,remotes,out,out_size)) {
 			return 1;
 		}
 	}
@@ -96,6 +94,5 @@ WL_API int decodeIR(struct ir_remote *remotes, char *out, size_t out_size) {
 
 WL_API hardware const* getHardware() {
 
-	initHardwareStruct();
-	return &hw;
+	return &udp_hw;
 }


### PR DESCRIPTION
- Remove initHardwareStruct from plugins. Change the global hw into a constant, and initialize it at compile time. 
- Rename global hw in plugins to include plugin name in the constant name